### PR TITLE
[RNMobile] Cover block media settings: dismiss BEFORE media picker

### DIFF
--- a/packages/block-library/src/cover/controls.native.js
+++ b/packages/block-library/src/cover/controls.native.js
@@ -22,6 +22,8 @@ import { useState } from '@wordpress/element';
 import { usePreferredColorSchemeStyle } from '@wordpress/compose';
 import { InspectorControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { useDispatch } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
 
 /**
  * Internal dependencies
@@ -63,6 +65,8 @@ function Controls( {
 			setAttributes( { minHeight: value } );
 		}
 	};
+
+	const { closeGeneralSidebar } = useDispatch( editPostStore );
 
 	const onOpacityChange = ( value ) => {
 		setAttributes( { dimRatio: value } );
@@ -251,7 +255,10 @@ function Controls( {
 						label={ __( 'Add image or video' ) }
 						labelStyle={ addMediaButtonStyle }
 						leftAlign
-						onPress={ openMediaOptionsRef.current }
+						onPress={ () => {
+							closeGeneralSidebar();
+							openMediaOptionsRef.current();
+						} }
 					/>
 				) }
 			</PanelBody>


### PR DESCRIPTION
Exploration of alternative to #2.

This causes the media picker to display and then disappear. This likely
occurs because the picker's presence is contained within the bottom
sheet itself. Because of this relationship, this approach will likely
not work.

This exploration was done to support the new add/edit media buttons
found within the Cover block inspector controls bottom sheet.
`react-native-modal` does not support displaying multiple modals on iOS,
therefore we must identify a proper method of transitioning from one
modal to the next.

https://user-images.githubusercontent.com/438664/105544757-f4795280-5cc0-11eb-9bd4-f8ccd8b3825c.MP4