### PR TITLE
[RNMobile] Cover block media settings: dismiss AFTER media picker

### DIFF
--- a/packages/block-library/src/cover/controls.native.js
+++ b/packages/block-library/src/cover/controls.native.js
@@ -251,7 +251,9 @@ function Controls( {
 						label={ __( 'Add image or video' ) }
 						labelStyle={ addMediaButtonStyle }
 						leftAlign
-						onPress={ openMediaOptionsRef.current }
+						onPress={ () => {
+							openMediaOptionsRef.current();
+						} }
 					/>
 				) }
 			</PanelBody>

--- a/packages/block-library/src/cover/edit.native.js
+++ b/packages/block-library/src/cover/edit.native.js
@@ -493,15 +493,22 @@ const Cover = ( {
 				</View>
 			</View>
 
-			<MediaUpload
-				allowedTypes={ ALLOWED_MEDIA_TYPES }
-				isReplacingMedia={ ! hasOnlyColorBackground }
-				onSelect={ onSelectMedia }
-				render={ ( { open, getMediaOptions } ) => {
-					openMediaOptionsRef.current = open;
-					return renderContent( getMediaOptions );
-				} }
-			/>
+			<InspectorControls>
+				<BottomSheetConsumer>
+					{ ( { onHandleDismissing } ) => (
+						<MediaUpload
+							allowedTypes={ ALLOWED_MEDIA_TYPES }
+							isReplacingMedia={ ! hasOnlyColorBackground }
+							onHandleDismissing={ onHandleDismissing }
+							onSelect={ onSelectMedia }
+							render={ ( { open, getMediaOptions } ) => {
+								openMediaOptionsRef.current = open;
+								return renderContent( getMediaOptions );
+							} }
+						/>
+					) }
+				</BottomSheetConsumer>
+			</InspectorControls>
 
 			{ shouldShowFailure && (
 				<View

--- a/packages/components/src/mobile/bottom-sheet/bottom-sheet-context.native.js
+++ b/packages/components/src/mobile/bottom-sheet/bottom-sheet-context.native.js
@@ -32,6 +32,8 @@ export const BottomSheetContext = createContext( {
 	// Android only: Function called to control android hardware back button functionality
 	// Return true if the bottom-sheet default close action shouldn't be called
 	onHandleHardwareButtonPress: () => {},
+	// Callback after bottom sheet has been dismissed
+	onHandleDismissing: () => {},
 } );
 
 export const {

--- a/packages/components/src/mobile/bottom-sheet/index.native.js
+++ b/packages/components/src/mobile/bottom-sheet/index.native.js
@@ -63,6 +63,8 @@ class BottomSheet extends Component {
 		this.onHandleHardwareButtonPress = this.onHandleHardwareButtonPress.bind(
 			this
 		);
+		this.onDismiss = this.onDismiss.bind( this );
+		this.onHandleDismissing = this.onHandleDismissing.bind( this );
 		this.keyboardWillShow = this.keyboardWillShow.bind( this );
 		this.keyboardDidHide = this.keyboardDidHide.bind( this );
 
@@ -243,6 +245,23 @@ class BottomSheet extends Component {
 		this.onShouldSetBottomSheetMaxHeight( true );
 	}
 
+	onDismiss() {
+		const { onDismiss } = this.props;
+		const { handleDismissing } = this.state;
+
+		if ( handleDismissing ) {
+			handleDismissing();
+		}
+
+		if ( onDismiss ) {
+			onDismiss();
+		}
+	}
+
+	onHandleDismissing( action ) {
+		this.setState( { handleDismissing: action } );
+	}
+
 	setIsFullScreen( isFullScreen ) {
 		if ( isFullScreen !== this.state.isFullScreen ) {
 			if ( isFullScreen ) {
@@ -380,9 +399,9 @@ class BottomSheet extends Component {
 				onBackdropPress={ this.onCloseBottomSheet }
 				onBackButtonPress={ this.onHardwareButtonPress }
 				onSwipe={ this.onCloseBottomSheet }
-				onDismiss={ Platform.OS === 'ios' ? onDismiss : undefined }
+				onDismiss={ Platform.OS === 'ios' ? this.onDismiss : undefined }
 				onModalHide={
-					Platform.OS === 'android' ? onDismiss : undefined
+					Platform.OS === 'android' ? this.onDismiss : undefined
 				}
 				swipeDirection="down"
 				onMoveShouldSetResponder={
@@ -433,6 +452,7 @@ class BottomSheet extends Component {
 									.onHandleClosingBottomSheet,
 								onHandleHardwareButtonPress: this
 									.onHandleHardwareButtonPress,
+								onHandleDismissing: this.onHandleDismissing,
 								listProps,
 								setIsFullScreen: this.setIsFullScreen,
 								safeAreaBottomInset,


### PR DESCRIPTION
Exploration of alternative to #1.

This requires `MediaPicker` to be wrapped in the
`BottomSheetContextProvider`, so that the `MediaUpload` may register an
`onDismiss` callback. Forcefully wrapping `MediaUpload` with 
`InspectorControls`, as done in this PR, allows access to `onDismiss`, but 
breaks rendering the media in the Cover block altogether. I have not yet
explored a fix that issue.

This exploration was done to support the new add/edit media buttons
found within the Cover block inspector controls bottom sheet.
`react-native-modal` does not support displaying multiple modals on iOS,
therefore we must identify a proper method of transitioning from one
modal to the next.

https://user-images.githubusercontent.com/438664/105544721-e7f4fa00-5cc0-11eb-86d1-ff3428f1f516.MP4